### PR TITLE
Set up Netlify redirect to handle SPA routes

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,3 +7,10 @@
   # create-react-app builds to this folder, Netlify should
   # serve all these files statically
   publish = "build"
+
+# this rule will serve the index.html instead of giving a 404
+# no matter what URL the browser requests
+[[redirects]]
+  from = "/*"
+  to = "index.html"
+  status = 200


### PR DESCRIPTION
This fixes the 404 errors on the [deployed app](https://whocalled.netlify.com/example). I added a redirect rule. Netlify will redirect everything to `index.html` so we can handle routes correctly.